### PR TITLE
Use #if DEBUG for debugging

### DIFF
--- a/FastColoredTextBox/FastColoredTextBox.cs
+++ b/FastColoredTextBox/FastColoredTextBox.cs
@@ -10,7 +10,6 @@
 //
 //  Copyright (C) Pavel Torgashov, 2011-2014. 
 
-// #define debug
 
 
 // -------------------------------------------------------------------------------
@@ -2924,7 +2923,7 @@ namespace FastColoredTextBoxNS
             if (!needRecalc)
                 return;
 
-#if debug
+#if DEBUG
             var sw = Stopwatch.StartNew();
 #endif
 
@@ -2964,7 +2963,7 @@ namespace FastColoredTextBoxNS
             
             AutoScrollMinSize = new Size(minWidth, TextHeight + Paddings.Top + Paddings.Bottom);
             UpdateScrollbars();
-#if debug
+#if DEBUG
             sw.Stop();
             Console.WriteLine("Recalc: " + sw.ElapsedMilliseconds);
 #endif
@@ -4789,7 +4788,7 @@ namespace FastColoredTextBoxNS
 
             if (needRecalcFoldingLines)
                 RecalcFoldingLines();
-#if debug
+#if DEBUG
             var sw = Stopwatch.StartNew();
 #endif
             visibleMarkers.Clear();
@@ -5026,7 +5025,7 @@ namespace FastColoredTextBoxNS
             currentLineBrush.Dispose();
             paddingBrush.Dispose();
             //
-#if debug
+#if DEBUG
             sw.Stop();
             Console.WriteLine("OnPaint: "+ sw.ElapsedMilliseconds);
 #endif
@@ -5700,7 +5699,7 @@ namespace FastColoredTextBoxNS
         /// <returns>Line and char position</returns>
         public Place PointToPlace(Point point)
         {
-            #if debug
+            #if DEBUG
             var sw = Stopwatch.StartNew();
             #endif
             point.Offset(HorizontalScroll.Value, VerticalScroll.Value);
@@ -5742,7 +5741,7 @@ namespace FastColoredTextBoxNS
             if (x > lines[iLine].Count)
                 x = lines[iLine].Count;
 
-#if debug
+#if DEBUG
             Console.WriteLine("PointToPlace: " + sw.ElapsedMilliseconds);
 #endif
 
@@ -5870,7 +5869,7 @@ namespace FastColoredTextBoxNS
                 return;
             }
             //
-#if debug
+#if DEBUG
             var sw = Stopwatch.StartNew();
             #endif
             CancelToolTip();
@@ -5904,7 +5903,7 @@ namespace FastColoredTextBoxNS
             //
             base.OnTextChanged(EventArgs.Empty);
             //
-#if debug
+#if DEBUG
             Console.WriteLine("OnTextChanged: " + sw.ElapsedMilliseconds);
 #endif
 
@@ -5934,7 +5933,7 @@ namespace FastColoredTextBoxNS
         /// </summary>
         public virtual void OnSelectionChanged()
         {
-#if debug
+#if DEBUG
             var sw = Stopwatch.StartNew();
             #endif
             //find folding markers for highlighting
@@ -5947,7 +5946,7 @@ namespace FastColoredTextBoxNS
             if (SelectionChanged != null)
                 SelectionChanged(this, new EventArgs());
 
-#if debug
+#if DEBUG
             Console.WriteLine("OnSelectionChanged: "+ sw.ElapsedMilliseconds);
 #endif
         }
@@ -7029,7 +7028,7 @@ namespace FastColoredTextBoxNS
 
         public virtual void OnSyntaxHighlight(TextChangedEventArgs args)
         {
-            #if debug
+            #if DEBUG
             Stopwatch sw = Stopwatch.StartNew();
             #endif
 
@@ -7056,7 +7055,7 @@ namespace FastColoredTextBoxNS
                     SyntaxHighlighter.HighlightSyntax(Language, range);
             }
 
-#if debug
+#if DEBUG
             Console.WriteLine("OnSyntaxHighlight: "+ sw.ElapsedMilliseconds);
 #endif
         }


### PR DESCRIPTION
The code ```  #define debug ``` has to be added every time code is debugged. Wouldn't would be better to use ```#DEBUG``` because ```#define DEBUG``` is automatically added when code is debugged using VS. 

@PavelTorgashov what do you think ?