### PR TITLE
Enabled basic mono support

### DIFF
--- a/FastColoredTextBox/FastColoredTextBox.csproj
+++ b/FastColoredTextBox/FastColoredTextBox.csproj
@@ -74,6 +74,9 @@
     </Compile>
     <Compile Include="LinesAccessor.cs" />
     <Compile Include="MacrosManager.cs" />
+    <Compile Include="MonoUtility.cs" />
+    <Compile Include="NativeMethods.cs" />
+    <Compile Include="NativeMethodsWrapper.cs" />
     <Compile Include="PlatformType.cs" />
     <Compile Include="Hotkeys.cs" />
     <Compile Include="Ruler.cs">

--- a/FastColoredTextBox/MonoUtility.cs
+++ b/FastColoredTextBox/MonoUtility.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FastColoredTextBoxNS
+{
+	internal class MonoUtility
+	{
+		// .Net 1.0 and 1.1 didn't have the PlatformID value for Unix, so Mono used the value 128.
+		private const PlatformID MonoUnix = (PlatformID)128;
+
+		public static bool IsLinux
+		{
+			get
+			{
+				return true;
+				PlatformID p = Environment.OSVersion.Platform;
+				return (p == PlatformID.Unix) || (p == PlatformID.MacOSX) || (p == MonoUnix);
+			}
+		}
+	}
+}

--- a/FastColoredTextBox/MonoUtility.cs
+++ b/FastColoredTextBox/MonoUtility.cs
@@ -13,7 +13,6 @@ namespace FastColoredTextBoxNS
 		{
 			get
 			{
-				return true;
 				PlatformID p = Environment.OSVersion.Platform;
 				return (p == PlatformID.Unix) || (p == PlatformID.MacOSX) || (p == MonoUnix);
 			}

--- a/FastColoredTextBox/NativeMethods.cs
+++ b/FastColoredTextBox/NativeMethods.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Runtime.InteropServices;
+
+namespace FastColoredTextBoxNS
+{
+	internal class NativeMethods
+	{
+		//[DllImport("user32.dll")]
+		//internal static extern IntPtr GetOpenClipboardWindow(); // unused ?
+
+		[DllImport("user32.dll")]
+		protected static extern bool CloseClipboard(); // corrected intptr -> bool
+
+		[DllImport("Imm32.dll")]
+		protected static extern IntPtr ImmGetContext(IntPtr hWnd);
+
+		[DllImport("Imm32.dll")]
+		protected static extern IntPtr ImmAssociateContext(IntPtr hWnd, IntPtr hIMC);
+
+		[DllImport("User32.dll")]
+		protected static extern bool CreateCaret(IntPtr hWnd, int hBitmap, int nWidth, int nHeight);
+
+		[DllImport("User32.dll")]
+		protected static extern bool SetCaretPos(int x, int y);
+
+		//[DllImport("User32.dll")]
+		//internal static extern bool DestroyCaret(); // unused ?
+
+		[DllImport("User32.dll")]
+		protected static extern bool ShowCaret(IntPtr hWnd);
+
+		[DllImport("User32.dll")]
+		protected static extern bool HideCaret(IntPtr hWnd);
+
+		[DllImport("User32.dll")]
+		protected static extern IntPtr SendMessage(IntPtr hwnd, int wMsg, int wParam, int lParam); // change corrent
+
+		[DllImport("kernel32.dll")]
+		protected static extern void GetNativeSystemInfo(ref SYSTEM_INFO lpSystemInfo);
+
+		[DllImport("kernel32.dll")]
+		protected static extern void GetSystemInfo(ref SYSTEM_INFO lpSystemInfo);
+
+		[StructLayout(LayoutKind.Sequential)]
+		internal struct SYSTEM_INFO
+		{
+			public ushort wProcessorArchitecture;
+			public ushort wReserved;
+			public uint dwPageSize;
+			public IntPtr lpMinimumApplicationAddress;
+			public IntPtr lpMaximumApplicationAddress;
+			public UIntPtr dwActiveProcessorMask;
+			public uint dwNumberOfProcessors;
+			public uint dwProcessorType;
+			public uint dwAllocationGranularity;
+			public ushort wProcessorLevel;
+			public ushort wProcessorRevision;
+		};
+	}
+}

--- a/FastColoredTextBox/NativeMethodsWrapper.cs
+++ b/FastColoredTextBox/NativeMethodsWrapper.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FastColoredTextBoxNS
+{
+	internal class NativeMethodsWrapper : NativeMethods
+	{
+		internal new static bool CloseClipboard()
+		{
+			if (MonoUtility.IsLinux)
+			{
+				return true; // TODO
+			}
+			else
+			{
+				return NativeMethods.CloseClipboard();
+			}
+		}
+
+		internal new static IntPtr ImmGetContext(IntPtr hWnd)
+		{
+			if (MonoUtility.IsLinux)
+			{
+				return IntPtr.Zero;
+			}
+			else
+			{
+				return NativeMethods.ImmGetContext(hWnd);
+			}
+		}
+
+		internal new static IntPtr ImmAssociateContext(IntPtr hWnd, IntPtr hIMC)
+		{
+			if (MonoUtility.IsLinux)
+			{
+				return IntPtr.Zero;
+			}
+			else
+			{
+				return NativeMethods.ImmAssociateContext(hWnd, hIMC);
+			}
+		}
+
+		internal new static bool CreateCaret(IntPtr hWnd, int hBitmap, int nWidth, int nHeight)
+		{
+			if (MonoUtility.IsLinux)
+			{
+				return true; // TODO
+			}
+			else
+			{
+				return NativeMethods.CreateCaret(hWnd, hBitmap, nWidth, nHeight);
+			}
+		}
+
+		internal new static bool SetCaretPos(int x, int y)
+		{
+			if (MonoUtility.IsLinux)
+			{
+				return true; // TODO
+			}
+			else
+			{
+				return NativeMethods.SetCaretPos(x, y);
+			}
+		}
+
+		internal new static bool ShowCaret(IntPtr hWnd)
+		{
+			if (MonoUtility.IsLinux)
+			{
+				return true; // TODO
+			}
+			else
+			{
+				return NativeMethods.ShowCaret(hWnd);
+			}
+		}
+
+		internal new static bool HideCaret(IntPtr hWnd)
+		{
+			if (MonoUtility.IsLinux)
+			{
+				return true; // TODO
+			}
+			else
+			{
+				return NativeMethods.HideCaret(hWnd);
+			}
+		}
+
+		internal new static IntPtr SendMessage(IntPtr hWnd, int wMsg, int wParam, int lParam)
+		{
+			if (MonoUtility.IsLinux)
+			{
+				return IntPtr.Zero; // TODO
+			}
+			else
+			{
+				return NativeMethods.SendMessage(hWnd, wMsg, wParam, lParam);
+			}
+		}
+
+		internal new static void GetNativeSystemInfo(ref SYSTEM_INFO lpSystemInfo)
+		{
+			if (MonoUtility.IsLinux)
+			{
+				throw new ApplicationException("This method is not supported in mono");
+			}
+			else
+			{
+				NativeMethods.GetNativeSystemInfo(ref lpSystemInfo);
+			}
+		}
+
+		internal new static void GetSystemInfo(ref SYSTEM_INFO lpSystemInfo)
+		{
+			if (MonoUtility.IsLinux)
+			{
+				throw new ApplicationException("This method is not supported in mono");
+			}
+			else
+			{
+				NativeMethods.GetSystemInfo(ref lpSystemInfo);
+			}
+		}
+	}
+}

--- a/FastColoredTextBox/PlatformType.cs
+++ b/FastColoredTextBox/PlatformType.cs
@@ -12,55 +12,40 @@ namespace FastColoredTextBoxNS
         const ushort PROCESSOR_ARCHITECTURE_AMD64 = 9;
         const ushort PROCESSOR_ARCHITECTURE_UNKNOWN = 0xFFFF;
 
-        [StructLayout(LayoutKind.Sequential)]
-        struct SYSTEM_INFO
-        {
-            public ushort wProcessorArchitecture;
-            public ushort wReserved;
-            public uint dwPageSize;
-            public IntPtr lpMinimumApplicationAddress;
-            public IntPtr lpMaximumApplicationAddress;
-            public UIntPtr dwActiveProcessorMask;
-            public uint dwNumberOfProcessors;
-            public uint dwProcessorType;
-            public uint dwAllocationGranularity;
-            public ushort wProcessorLevel;
-            public ushort wProcessorRevision;
-        };
-
-        [DllImport("kernel32.dll")]
-        static extern void GetNativeSystemInfo(ref SYSTEM_INFO lpSystemInfo);
-
-        [DllImport("kernel32.dll")]
-        static extern void GetSystemInfo(ref SYSTEM_INFO lpSystemInfo);
-
         public static Platform GetOperationSystemPlatform()
         {
-            var sysInfo = new SYSTEM_INFO();
-
-            // WinXP and older - use GetNativeSystemInfo
-            if (Environment.OSVersion.Version.Major > 5 ||
-                (Environment.OSVersion.Version.Major == 5 && Environment.OSVersion.Version.Minor >= 1))
+            if(MonoUtility.IsLinux)
             {
-                GetNativeSystemInfo(ref sysInfo);
+                return Platform.Unknown;
             }
-            // else use GetSystemInfo
             else
             {
-                GetSystemInfo(ref sysInfo);
-            }
+                var sysInfo = new NativeMethods.SYSTEM_INFO();
 
-            switch (sysInfo.wProcessorArchitecture)
-            {
-                case PROCESSOR_ARCHITECTURE_IA64:
-                case PROCESSOR_ARCHITECTURE_AMD64:
-                    return Platform.X64;
+                // WinXP and older - use GetNativeSystemInfo
+                if (Environment.OSVersion.Version.Major > 5 ||
+                    (Environment.OSVersion.Version.Major == 5 && Environment.OSVersion.Version.Minor >= 1))
+                {
+                    NativeMethodsWrapper.GetNativeSystemInfo(ref sysInfo);
+                }
+                // else use GetSystemInfo
+                else
+                {
+                    NativeMethodsWrapper.GetSystemInfo(ref sysInfo);
+                }
 
-                case PROCESSOR_ARCHITECTURE_INTEL:
-                    return Platform.X86;
+                switch (sysInfo.wProcessorArchitecture)
+                {
+                    case PROCESSOR_ARCHITECTURE_IA64:
+                    case PROCESSOR_ARCHITECTURE_AMD64:
+                        return Platform.X64;
 
-                default:
-                    return Platform.Unknown;
+                    case PROCESSOR_ARCHITECTURE_INTEL:
+                        return Platform.X86;
+
+                    default:
+                        return Platform.Unknown;
+                }
             }
         }
     }


### PR DESCRIPTION
I've packed the native mthods into a own class and added a wrapper so they don't get used by accident.
This version should now compile into one dll for windows and mono. And detects the optional features for windows during runtime.
A replacement for the default placeholder moethods is possible to add in the NativeMethodsWrapper class.
Many ideas were taken from the the fork of @remco138, thanks for that ;)

Greets
~Splamy
