### PR TITLE
Rename GoToForm.designer.cs for mono/linux

### DIFF
--- a/FastColoredTextBox/FastColoredTextBox.csproj
+++ b/FastColoredTextBox/FastColoredTextBox.csproj
@@ -62,7 +62,7 @@
     <Compile Include="GoToForm.cs">
       <SubType>Form</SubType>
     </Compile>
-    <Compile Include="GoToForm.designer.cs">
+    <Compile Include="GoToForm.Designer.cs">
       <DependentUpon>GoToForm.cs</DependentUpon>
     </Compile>
     <Compile Include="Hints.cs" />


### PR DESCRIPTION
Renamed GoToForm.designer.cs to GoToForm.Designer.cs in the solution file to make compile it on linux/mono framework