### PR TITLE
Fix: Refresh tooltip

### DIFF
--- a/FastColoredTextBox/AutocompleteMenu.cs
+++ b/FastColoredTextBox/AutocompleteMenu.cs
@@ -389,8 +389,9 @@ namespace FastColoredTextBoxNS
                     if(!args.Cancel)
                         Menu.Show(tb, point);
                 }
-                else
-                    Invalidate();
+
+                DoSelectedVisible();
+                Invalidate();
             }
             else
                 Menu.Close();


### PR DESCRIPTION
How to reproduce:

Let's say we have the following autocomplete menu items and the same corresponding tooltip values:

G0 ^
G0 X^
G0 Y^
G0 Z^
G2 ^
G2 X^
G2 Y^
G2 Z^

Autocomplete menu is set to show after 1 character and tooltip to show always:
popupMenu.MinFragmentLength = 1; // show menu after that many characters
popupMenu.AllowTabKey = true;
popupMenu.AutoClose = false;
popupMenu.ToolTip.ShowAlways = true; // this isn't really working...
popupMenu.ToolTipDuration = Int32.MaxValue; // workaround for show always
popupMenu.SearchPattern = @"[\w\.#() ]";

Now, there are 2 things that aren't working which comes down to the same issue - tooltip value not being refreshed when autocomplete menu elements have changed:
1. Start typing first character G - autocomplete menu shows G0 ^ and tooltip the same. Then type 2 (now we have G2) - autocomplete menu shows G2 ^ however tooltip still shows G0 ^.
2. As earlier type G2 and press escape key to close the autocomplete menu. Then press ctrl + space to show it again - autocomplete menu shows correctly G2 ^ however tooltip still shows G0 ^. 

