### PR TITLE
Fixed draw slowdown when using extremly big wordwrap lines.

### DIFF
--- a/FastColoredTextBox/FastColoredTextBox.cs
+++ b/FastColoredTextBox/FastColoredTextBox.cs
@@ -5068,6 +5068,13 @@ namespace FastColoredTextBoxNS
                 for (int iWordWrapLine = 0; iWordWrapLine < lineInfo.WordWrapStringsCount; iWordWrapLine++)
                 {
                     y = lineInfo.startY + iWordWrapLine*CharHeight - VerticalScroll.Value;
+                    // break if too long line (important for extremly big lines)
+                    if (y > VerticalScroll.Value + ClientSize.Height)
+                        break;
+                    // continue if wordWrapLine isn't seen yet (important for extremly big lines)
+                    if (lineInfo.startY + iWordWrapLine * CharHeight < VerticalScroll.Value)
+                        continue;
+
                     //indent
                     var indent = iWordWrapLine == 0 ? 0 : lineInfo.wordWrapIndent * CharWidth;
                     //draw chars
@@ -5837,7 +5844,7 @@ namespace FastColoredTextBoxNS
             Selection = new Range(this, toX, p.iLine, fromX, p.iLine);
         }
 
-        private int YtoLineIndex(int y)
+        public int YtoLineIndex(int y)
         {
             int i = LineInfos.BinarySearch(new LineInfo(-10), new LineYComparer(y));
             i = i < 0 ? -i - 2 : i;
@@ -5876,6 +5883,15 @@ namespace FastColoredTextBoxNS
                 iLine = FindPrevVisibleLine(iLine);
             //
             int iWordWrapLine = LineInfos[iLine].WordWrapStringsCount;
+
+            //set iWordWrapLine more accurate (important for extremly big lines)
+            if (y > point.Y)
+            {
+                int approximatelyLines = (y - point.Y - CharHeight) / CharHeight;
+                y -= approximatelyLines * CharHeight;
+                iWordWrapLine -= approximatelyLines;
+            }
+
             do
             {
                 iWordWrapLine--;

--- a/FastColoredTextBox/Properties/AssemblyInfo.cs
+++ b/FastColoredTextBox/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.16.23.0")]
-[assembly: AssemblyFileVersion("2.16.23.0")]
+[assembly: AssemblyVersion("2.16.24.0")]
+[assembly: AssemblyFileVersion("2.16.24.0")]
  


### PR DESCRIPTION
I found significant slowdown when using an extremly big lines in my project. In this request I fixed those bugs. Also I've changed privacy of YtoLineIndex function cause I use it in my project.
It would be nice to push this changes in the Nuget.