### PR TITLE
Do not remember and restore brackets when using SyntaxDescriptor

### DIFF
--- a/FastColoredTextBox/SyntaxHighlighter.cs
+++ b/FastColoredTextBox/SyntaxHighlighter.cs
@@ -526,7 +526,6 @@ namespace FastColoredTextBoxNS
             for (int i = 0; i < resilientStyles.Count; i++)
                 range.tb.Styles[l + i] = resilientStyles[i];
             //brackets
-            char[] oldBrackets = RememberBrackets(range.tb);
             range.tb.LeftBracket = desc.leftBracket;
             range.tb.RightBracket = desc.rightBracket;
             range.tb.LeftBracket2 = desc.leftBracket2;
@@ -541,22 +540,6 @@ namespace FastColoredTextBoxNS
             //folding markers
             foreach (FoldingDesc folding in desc.foldings)
                 range.SetFoldingMarkers(folding.startMarkerRegex, folding.finishMarkerRegex, folding.options);
-
-            //
-            RestoreBrackets(range.tb, oldBrackets);
-        }
-
-        protected void RestoreBrackets(FastColoredTextBox tb, char[] oldBrackets)
-        {
-            tb.LeftBracket = oldBrackets[0];
-            tb.RightBracket = oldBrackets[1];
-            tb.LeftBracket2 = oldBrackets[2];
-            tb.RightBracket2 = oldBrackets[3];
-        }
-
-        protected char[] RememberBrackets(FastColoredTextBox tb)
-        {
-            return new[] { tb.LeftBracket, tb.RightBracket, tb.LeftBracket2, tb.RightBracket2 };
         }
 
         protected void InitCShaprRegex()


### PR DESCRIPTION
Do not remember and restore brackets configuration in `HighlightSyntax(SyntaxDescriptor desc, Range range)`, because it overrides the brackets configuration you put in the xml file description.