### PR TITLE
Do not find "First not empty line" to collapse a folding block

### DIFF
--- a/FastColoredTextBox/FastColoredTextBox.cs
+++ b/FastColoredTextBox/FastColoredTextBox.cs
@@ -6598,19 +6598,12 @@ namespace FastColoredTextBoxNS
             if (from == to)
                 return;
 
-            //find first non empty line
-            for (; from <= to; from++)
-            {
-                if (GetLineText(from).Trim().Length > 0)
-                {
-                    //hide lines
-                    for (int i = from + 1; i <= to; i++)
-                        SetVisibleState(i, VisibleState.Hidden);
-                    SetVisibleState(from, VisibleState.StartOfHiddenBlock);
-                    Invalidate();
-                    break;
-                }
-            }
+            //hide lines
+            for (int i = from + 1; i <= to; i++)
+                SetVisibleState(i, VisibleState.Hidden);
+            SetVisibleState(from, VisibleState.StartOfHiddenBlock);
+            Invalidate();
+
             //Move caret outside
             from = Math.Min(fromLine, toLine);
             to = Math.Max(fromLine, toLine);


### PR DESCRIPTION
Don't find the first "not empty line" when folding a block. When you create your own FoldingMarkers to make custom folding blocks you may want to be able to collapse on empty lines. In my case, for example, I want to create folding block on specifics line numbers, even if they are empty.