### PR TITLE
Fix/text changed event args changed range

### DIFF
--- a/FastColoredTextBox/AutocompleteItem.cs
+++ b/FastColoredTextBox/AutocompleteItem.cs
@@ -181,11 +181,11 @@ namespace FastColoredTextBoxNS
             {
                 for (int iLine = p1.iLine + 1; iLine <= p2.iLine; iLine++)
                 {
-                    e.Tb.Selection.Start = new Place(0, iLine);
+                    e.Tb.Selection.SetStartAndEnd(new Place(0, iLine));
                     e.Tb.DoAutoIndent(iLine);
                 }
             }
-            e.Tb.Selection.Start = p1;
+            e.Tb.Selection.SetStartAndEnd(p1);
             //move caret position right and find char ^
             while (e.Tb.Selection.CharBeforeStart != '^')
                 if (!e.Tb.Selection.GoRightThroughFolded())

--- a/FastColoredTextBox/Bookmarks.cs
+++ b/FastColoredTextBox/Bookmarks.cs
@@ -231,7 +231,7 @@ namespace FastColoredTextBoxNS
         /// </summary>
         public virtual void DoVisible()
         {
-            TB.Selection.Start = new Place(0, LineIndex);
+            TB.Selection.SetStartAndEnd(new Place(0, LineIndex));
             TB.DoRangeVisible(TB.Selection, true);
             TB.Invalidate();
         }

--- a/FastColoredTextBox/Commands.cs
+++ b/FastColoredTextBox/Commands.cs
@@ -33,7 +33,7 @@ namespace FastColoredTextBoxNS
                 case '\n': MergeLines(sel.Start.iLine, ts); break;
                 case '\r': break;
                 case '\b':
-                    ts.CurrentTB.Selection.Start = lastSel.Start;
+                    ts.CurrentTB.Selection.SetStartAndEnd(lastSel.Start);
                     char cc = '\x0';
                     if (deletedChar != '\x0')
                     {
@@ -45,12 +45,12 @@ namespace FastColoredTextBoxNS
                     ts.CurrentTB.ExpandBlock(sel.Start.iLine);
                     for (int i = sel.FromX; i < lastSel.FromX; i++)
                         ts[sel.Start.iLine].RemoveAt(sel.Start.iChar);
-                    ts.CurrentTB.Selection.Start = sel.Start;
+                    ts.CurrentTB.Selection.SetStartAndEnd(sel.Start);
                     break;
                 default:
                     ts.CurrentTB.ExpandBlock(sel.Start.iLine);
                     ts[sel.Start.iLine].RemoveAt(sel.Start.iChar);
-                    ts.CurrentTB.Selection.Start = sel.Start;
+                    ts.CurrentTB.Selection.SetStartAndEnd(sel.Start);
                     break;
             }
 
@@ -112,7 +112,7 @@ namespace FastColoredTextBoxNS
                     {
                         deletedChar = ts[tb.Selection.Start.iLine][tb.Selection.Start.iChar - 1].c;
                         ts[tb.Selection.Start.iLine].RemoveAt(tb.Selection.Start.iChar - 1);
-                        tb.Selection.Start = new Place(tb.Selection.Start.iChar - 1, tb.Selection.Start.iLine);
+                        tb.Selection.SetStartAndEnd(new Place(tb.Selection.Start.iChar - 1, tb.Selection.Start.iLine));
                     }
                     break;
                 case '\t':
@@ -123,11 +123,11 @@ namespace FastColoredTextBoxNS
                     for (int i = 0; i < spaceCountNextTabStop; i++)
                         ts[tb.Selection.Start.iLine].Insert(tb.Selection.Start.iChar, new Char(' '));
 
-                    tb.Selection.Start = new Place(tb.Selection.Start.iChar + spaceCountNextTabStop, tb.Selection.Start.iLine);
+                    tb.Selection.SetStartAndEnd(new Place(tb.Selection.Start.iChar + spaceCountNextTabStop, tb.Selection.Start.iLine));
                     break;
                 default:
                     ts[tb.Selection.Start.iLine].Insert(tb.Selection.Start.iChar, new Char(c));
-                    tb.Selection.Start = new Place(tb.Selection.Start.iChar + 1, tb.Selection.Start.iLine);
+                    tb.Selection.SetStartAndEnd(new Place(tb.Selection.Start.iChar + 1, tb.Selection.Start.iLine));
                     break;
             }
         }
@@ -144,7 +144,7 @@ namespace FastColoredTextBoxNS
             else
                 BreakLines(tb.Selection.Start.iLine, tb.Selection.Start.iChar, ts);
 
-            tb.Selection.Start = new Place(0, tb.Selection.Start.iLine + 1);
+            tb.Selection.SetStartAndEnd(new Place(0, tb.Selection.Start.iLine + 1));
             ts.NeedRecalc(new TextSource.TextChangedEventArgs(0, 1));
         }
 
@@ -172,7 +172,7 @@ namespace FastColoredTextBoxNS
                 ts[i].AddRange(ts[i + 1]);
                 ts.RemoveLine(i + 1);
             }
-            tb.Selection.Start = new Place(pos, i);
+            tb.Selection.SetStartAndEnd(new Place(pos, i));
             ts.NeedRecalc(new TextSource.TextChangedEventArgs(0, 1));
         }
 
@@ -238,11 +238,11 @@ namespace FastColoredTextBoxNS
             {
                 tb.Selection.BeginUpdate();
                 char cc = '\x0';
-                
+
                 if (ts.Count == 0)
                 {
                     InsertCharCommand.InsertLine(ts);
-                    tb.Selection.Start = Place.Empty;
+                    tb.Selection.SetStartAndEnd(Place.Empty);
                 }
                 tb.ExpandBlock(tb.Selection.Start.iLine);
                 var len = insertedText.Length;
@@ -311,7 +311,7 @@ namespace FastColoredTextBoxNS
             tb.Selection.BeginUpdate();
             for (int i = 0; i<ranges.Count; i++)
             {
-                tb.Selection.Start = ranges[i].Start;
+                tb.Selection.SetStartAndEnd(ranges[i].Start);
                 for (int j = 0; j < insertedText.Length; j++)
                     tb.Selection.GoRight(true);
                 ClearSelected(ts);
@@ -407,7 +407,7 @@ namespace FastColoredTextBoxNS
         /// </summary>
         public override void Undo()
         {
-            ts.CurrentTB.Selection.Start = new Place(sel.FromX, Math.Min(sel.Start.iLine, sel.End.iLine));
+            ts.CurrentTB.Selection.SetStartAndEnd(new Place(sel.FromX, Math.Min(sel.Start.iLine, sel.End.iLine)));
             ts.OnTextChanging();
             InsertTextCommand.InsertText(deletedText, ts);
             ts.OnTextChanged(sel.Start.iLine, sel.End.iLine);
@@ -455,7 +455,7 @@ namespace FastColoredTextBoxNS
                 InsertCharCommand.MergeLines(fromLine, ts);
             }
             //
-            tb.Selection.Start = new Place(fromChar, fromLine);
+            tb.Selection.SetStartAndEnd(new Place(fromChar, fromLine));
             //
             ts.NeedRecalc(new TextSource.TextChangedEventArgs(fromLine, toLine));
         }
@@ -512,7 +512,7 @@ namespace FastColoredTextBoxNS
             tb.Selection.BeginUpdate();
             for (int i = 0; i < ranges.Count; i++)
             {
-                tb.Selection.Start = ranges[i].ReplacedRange.Start;
+                tb.Selection.SetStartAndEnd(ranges[i].ReplacedRange.Start);
                 for (int j = 0; j < ranges[i].ReplaceText.Length; j++)
                     tb.Selection.GoRight(true);
                 ClearSelectedCommand.ClearSelected(ts);
@@ -597,12 +597,12 @@ namespace FastColoredTextBoxNS
                 var iLine = iLines[i];
 
                 if(iLine < ts.Count)
-                    tb.Selection.Start = new Place(0, iLine);
+                    tb.Selection.SetStartAndEnd(new Place(0, iLine));
                 else
-                    tb.Selection.Start = new Place(ts[ts.Count - 1].Count, ts.Count - 1);
+                    tb.Selection.SetStartAndEnd(new Place(ts[ts.Count - 1].Count, ts.Count - 1));
 
                 InsertCharCommand.InsertLine(ts);
-                tb.Selection.Start = new Place(0, iLine);
+                tb.Selection.SetStartAndEnd(new Place(0, iLine));
                 var text = prevText[prevText.Count - i - 1];
                 InsertTextCommand.InsertText(text, ts);
                 ts[iLine].IsChanged = true;
@@ -633,12 +633,12 @@ namespace FastColoredTextBoxNS
             for(int i = iLines.Count - 1; i >= 0; i--)
             {
                 var iLine = iLines[i];
-                
+
                 prevText.Add(ts[iLine].Text);//backward
                 ts.RemoveLine(iLine);
                 //ts.OnTextChanged(ranges[i].Start.iLine, ranges[i].End.iLine);
             }
-            tb.Selection.Start = new Place(0, 0);
+            tb.Selection.SetStartAndEnd(new Place(0, 0));
             tb.Selection.EndUpdate();
             ts.NeedRecalc(new TextSource.TextChangedEventArgs(0, 1));
 

--- a/FastColoredTextBox/FastColoredTextBox.cs
+++ b/FastColoredTextBox/FastColoredTextBox.cs
@@ -1477,7 +1477,7 @@ namespace FastColoredTextBoxNS
         public int SelectionStart
         {
             get { return Math.Min(PlaceToPosition(Selection.Start), PlaceToPosition(Selection.End)); }
-            set { Selection.Start = PositionToPlace(value); }
+            set { Selection.SetStartAndEnd(PositionToPlace(value)); }
         }
 
         /// <summary>
@@ -2246,7 +2246,7 @@ namespace FastColoredTextBoxNS
         {
             if (iLine >= LinesCount) return;
             lastNavigatedDateTime = lines[iLine].LastVisit;
-            Selection.Start = new Place(0, iLine);
+            Selection.SetStartAndEnd(new Place(0, iLine));
             DoSelectionVisible();
         }
 
@@ -2591,8 +2591,8 @@ namespace FastColoredTextBoxNS
                 if (Selection.Start.iLine >= 0 && Selection.Start.iLine < LinesCount)
                 {
                     int iLine = Selection.Start.iLine;
-                    RemoveLines(new List<int> {iLine});
-                    Selection.Start = new Place(0, Math.Max(0, Math.Min(iLine, LinesCount - 1)));
+                    RemoveLines(new List<int> { iLine });
+                    Selection.SetStartAndEnd(new Place(0, Math.Max(0, Math.Min(iLine, LinesCount - 1))));
                 }
             }
         }
@@ -2646,9 +2646,9 @@ namespace FastColoredTextBoxNS
         public void GoEnd()
         {
             if (lines.Count > 0)
-                Selection.Start = new Place(lines[lines.Count - 1].Count, lines.Count - 1);
+                Selection.SetStartAndEnd(new Place(lines[lines.Count - 1].Count, lines.Count - 1));
             else
-                Selection.Start = new Place(0, 0);
+                Selection.SetStartAndEnd(new Place(0, 0));
 
             DoCaretVisible();
         }
@@ -2658,7 +2658,7 @@ namespace FastColoredTextBoxNS
         /// </summary>
         public void GoHome()
         {
-            Selection.Start = new Place(0, 0);
+            Selection.SetStartAndEnd(new Place(0, 0));
 
             DoCaretVisible();
             //VerticalScroll.Value = 0;
@@ -2839,9 +2839,9 @@ namespace FastColoredTextBoxNS
             try
             {
                 if (lines.Count > 0)
-                    Selection.Start = new Place(lines[lines.Count - 1].Count, lines.Count - 1);
+                    Selection.SetStartAndEnd(new Place(lines[lines.Count - 1].Count, lines.Count - 1));
                 else
-                    Selection.Start = new Place(0, 0);
+                    Selection.SetStartAndEnd(new Place(0, 0));
 
                 //remember last caret position
                 Place last = Selection.Start;
@@ -3022,7 +3022,7 @@ namespace FastColoredTextBoxNS
             Selection.BeginUpdate();
             try
             {
-                Selection.Start = new Place(lineLength, Selection.Start.iLine);
+                Selection.SetStartAndEnd(new Place(lineLength, Selection.Start.iLine));
                 lines.Manager.ExecuteCommand(new InsertTextCommand(TextSource, new string(' ', count)));
             }
             finally
@@ -4146,7 +4146,7 @@ namespace FastColoredTextBoxNS
                 for (int i = Selection.Start.iLine; i <= Selection.End.iLine; i++)
                     temp.Add(i);
                 RemoveLines(temp);
-                Selection.Start = new Place(GetLineLength(iLine), iLine);
+                Selection.SetStartAndEnd(new Place(GetLineLength(iLine), iLine));
                 SelectedText = "\n" + text;
                 Selection.Start = new Place(prevSelection.Start.iChar, prevSelection.Start.iLine + 1);
                 Selection.End = new Place(prevSelection.End.iChar, prevSelection.End.iLine + 1);
@@ -4174,7 +4174,7 @@ namespace FastColoredTextBoxNS
                 for (int i = Selection.Start.iLine; i <= Selection.End.iLine; i++)
                     temp.Add(i);
                 RemoveLines(temp);
-                Selection.Start = new Place(0, iLine - 1);
+                Selection.SetStartAndEnd(new Place(0, iLine - 1));
                 SelectedText = text + "\n";
                 Selection.Start = new Place(prevSelection.Start.iChar, prevSelection.Start.iLine - 1);
                 Selection.End = new Place(prevSelection.End.iChar, prevSelection.End.iLine - 1);
@@ -4553,13 +4553,13 @@ namespace FastColoredTextBoxNS
                         continue;
 
                     if (oldSel.Start.iLine == i && oldSel.Start.iChar > cap.Index)
-                        oldSel.Start = new Place(oldSel.Start.iChar + addSpaces, i);
+                        oldSel.SetStartAndEnd(new Place(oldSel.Start.iChar + addSpaces, i));
 
                     if (addSpaces > 0)
                         texts[i] = texts[i].Insert(cap.Index, new string(' ', addSpaces));
                     else
                         texts[i] = texts[i].Remove(cap.Index + addSpaces, -addSpaces);
-                    
+
                     changed[i] = true;
                     was = true;
                 }
@@ -4708,7 +4708,7 @@ namespace FastColoredTextBoxNS
             //insert start spaces
             if (needToInsert == 0)
                 return;
-            Selection.Start = new Place(0, iLine);
+            Selection.SetStartAndEnd(new Place(0, iLine));
             if (needToInsert > 0)
                 InsertText(new String(' ', needToInsert));
             else
@@ -4718,7 +4718,7 @@ namespace FastColoredTextBoxNS
                 ClearSelected();
             }
 
-            Selection.Start = new Place(Math.Min(lines[iLine].Count, Math.Max(0, oldStart.iChar + needToInsert)), iLine);
+            Selection.SetStartAndEnd(new Place(Math.Min(lines[iLine].Count, Math.Max(0, oldStart.iChar + needToInsert)), iLine));
         }
 
         /// <summary>
@@ -5566,15 +5566,15 @@ namespace FastColoredTextBoxNS
 
             if (Selection.ColumnSelectionMode)
             {
-                Selection.Start = PointToPlaceSimple(e.Location);
+                Selection.SetStartAndEnd(PointToPlaceSimple(e.Location));
                 Selection.ColumnSelectionMode = true;
             }
             else
             {
                 if (VirtualSpace)
-                    Selection.Start = PointToPlaceSimple(e.Location);
+                    Selection.SetStartAndEnd(PointToPlaceSimple(e.Location));
                 else
-                    Selection.Start = PointToPlace(e.Location);
+                    Selection.SetStartAndEnd(PointToPlace(e.Location));
             }
 
             if ((lastModifiers & Keys.Shift) != 0)
@@ -5805,11 +5805,11 @@ namespace FastColoredTextBoxNS
                     Selection.BeginUpdate();
                     if (Selection.ColumnSelectionMode)
                     {
-                        Selection.Start = place;
+                        Selection.SetStartAndEnd(place);
                         Selection.ColumnSelectionMode = true;
                     }
                     else
-                        Selection.Start = place;
+                        Selection.SetStartAndEnd(place);
                     Selection.End = oldEnd;
                     Selection.EndUpdate();
                     DoCaretVisible();
@@ -6643,7 +6643,7 @@ namespace FastColoredTextBoxNS
             int newLine = FindNextVisibleLine(to);
             if (newLine == to)
                 newLine = FindPrevVisibleLine(from);
-            Selection.Start = new Place(0, newLine);
+            Selection.SetStartAndEnd(new Place(0, newLine));
             //
             needRecalc = true;
             Invalidate();
@@ -6695,7 +6695,7 @@ namespace FastColoredTextBoxNS
             {
                 if (!Selection.ReadOnly)
                 {
-                    Selection.Start = new Place(this[Selection.Start.iLine].StartSpacesCount, Selection.Start.iLine);
+                    Selection.SetStartAndEnd(new Place(this[Selection.Start.iLine].StartSpacesCount, Selection.Start.iLine));
                     //insert tab as spaces
                     int spaces = TabLength - (Selection.Start.iChar % TabLength);
                     //replace mode? select forward chars
@@ -6736,7 +6736,7 @@ namespace FastColoredTextBoxNS
             for (int i = from; i <= to; i++)
             {
                 if (lines[i].Count == 0) continue;
-                Selection.Start = new Place(startChar, i);
+                Selection.SetStartAndEnd(new Place(startChar, i));
                 lines.Manager.ExecuteCommand(new InsertTextCommand(TextSource, new String(' ', TabLength)));
             }
 
@@ -6947,7 +6947,7 @@ namespace FastColoredTextBoxNS
             int spaces = GetMinStartSpacesCount(from, to);
             for (int i = from; i <= to; i++)
             {
-                Selection.Start = new Place(spaces, i);
+                Selection.SetStartAndEnd(new Place(spaces, i));
                 lines.Manager.ExecuteCommand(new InsertTextCommand(TextSource, prefix));
             }
             Selection.Start = new Place(0, from);
@@ -7123,7 +7123,7 @@ namespace FastColoredTextBoxNS
                 if (range.CharAfterStart == rightBracket) counter--;
                 if (counter == 1)
                 {
-                    range.Start = new Place(range.Start.iChar + (!includeBrackets ? 1 : 0), range.Start.iLine);
+                    range.SetStartAndEnd(new Place(range.Start.iChar + (!includeBrackets ? 1 : 0), range.Start.iLine));
                     leftBracketPosition = range;
                     break;
                 }
@@ -7501,7 +7501,7 @@ window.status = ""#print"";
                 IsChanged = false;
                 throw;
             }
-            Selection.Start = Place.Empty;
+            Selection.SetStartAndEnd(Place.Empty);
             DoSelectionVisible();
         }
 
@@ -7671,7 +7671,7 @@ window.status = ""#print"";
         void ISupportInitialize.EndInit()
         {
             OnTextChanged();
-            Selection.Start = Place.Empty;
+            Selection.SetStartAndEnd(Place.Empty);
             DoCaretVisible();
             IsChanged = false;
             ClearUndo();
@@ -7737,7 +7737,7 @@ window.status = ""#print"";
             {
                 Selection.BeginUpdate();
                 // Insert text
-                Selection.Start = place;
+                Selection.SetStartAndEnd(place);
                 InsertText(text);
                 // Select inserted text
                 Selection = new Range(this, place, Selection.Start);
@@ -7844,7 +7844,7 @@ window.status = ""#print"";
             {
                 Selection.BeginUpdate();
                 // Insert text
-                Selection.Start = place;
+                Selection.SetStartAndEnd(place);
                 InsertText(text);
                 // Select inserted text
                 Selection = new Range(this, place, Selection.Start);
@@ -8004,7 +8004,7 @@ window.status = ""#print"";
             if (e.Data.GetDataPresent(DataFormats.Text))
             {
                 Point p = PointToClient(new Point(e.X, e.Y));
-                Selection.Start = PointToPlace(p);
+                Selection.SetStartAndEnd(PointToPlace(p));
                 if (p.Y < 6 && VerticalScroll.Visible && VerticalScroll.Value > 0)
                     VerticalScroll.Value = Math.Max(0, VerticalScroll.Value - charHeight);
 

--- a/FastColoredTextBox/FastColoredTextBox.cs
+++ b/FastColoredTextBox/FastColoredTextBox.cs
@@ -145,7 +145,8 @@ namespace FastColoredTextBoxNS
             InitTextSource(CreateTextSource());
             if (lines.Count == 0)
                 lines.InsertLine(0, lines.CreateLine());
-            selection = new Range(this) {Start = new Place(0, 0)};
+            selection = new Range(this);
+            selection.SetStartAndEnd(new Place(0, 0));
             //default settings
             Cursor = Cursors.IBeam;
             BackColor = Color.White;

--- a/FastColoredTextBox/FindForm.cs
+++ b/FastColoredTextBox/FindForm.cs
@@ -62,7 +62,7 @@ namespace FastColoredTextBoxNS
                 //
                 if (range.Start >= startPlace && startPlace > Place.Empty)
                 {
-                    tb.Selection.Start = new Place(0, 0);
+                    tb.Selection.SetStartAndEnd(new Place(0, 0));
                     FindNext(pattern);
                     return;
                 }

--- a/FastColoredTextBox/Range.cs
+++ b/FastColoredTextBox/Range.cs
@@ -157,9 +157,9 @@ namespace FastColoredTextBoxNS
         {
             ColumnSelectionMode = false;
 
-            Start = new Place(0, 0);
+            SetStartAndEnd(new Place(0, 0));
             if (tb.LinesCount == 0)
-                Start = new Place(0, 0);
+                SetStartAndEnd(new Place(0, 0));
             else
             {
                 end = new Place(0, 0);
@@ -729,6 +729,12 @@ namespace FastColoredTextBoxNS
         }
 
         /// <summary>
+        /// Setter changing both, the Start and End property to the same value
+        /// </summary>
+        /// <param name="value">The new place</param>
+        public void SetStartAndEnd(Place value) { End = Start = value; }
+
+        /// <summary>
         /// Set style for range
         /// </summary>
         public void SetStyle(Style style)
@@ -1214,7 +1220,7 @@ namespace FastColoredTextBoxNS
             var mask = tb.GetStyleIndexMask(new Style[] { style });
             //
             Range r = new Range(tb);
-            r.Start = Start;
+            r.SetStartAndEnd(Start);
             //go left, check style
             while (r.GoLeftThroughFolded())
             {
@@ -1229,7 +1235,7 @@ namespace FastColoredTextBoxNS
             }
             Place startFragment = r.Start;
 
-            r.Start = Start;
+            r.SetStartAndEnd(Start);
             //go right, check style
             do
             {
@@ -1252,7 +1258,7 @@ namespace FastColoredTextBoxNS
         public Range GetFragment(string allowedSymbolsPattern, RegexOptions options)
         {
             Range r = new Range(tb);
-            r.Start = Start;
+            r.SetStartAndEnd(Start);
             Regex regex = new Regex(allowedSymbolsPattern, options);
             //go left, check symbols
             while (r.GoLeftThroughFolded())
@@ -1265,7 +1271,7 @@ namespace FastColoredTextBoxNS
             }
             Place startFragment = r.Start;
 
-            r.Start = Start;
+            r.SetStartAndEnd(Start);
             //go right, check symbols
             do
             {

--- a/FastColoredTextBox/Range.cs
+++ b/FastColoredTextBox/Range.cs
@@ -177,7 +177,7 @@ namespace FastColoredTextBoxNS
             get { return start; }
             set
             {
-                end = start = value;
+                start = value;
                 preferedPos = -1;
                 OnSelectionChanged();
             }

--- a/FastColoredTextBox/ReplaceForm.cs
+++ b/FastColoredTextBox/ReplaceForm.cs
@@ -85,7 +85,7 @@ namespace FastColoredTextBoxNS
             }
             if (range.Start >= startPlace && startPlace > Place.Empty)
             {
-                tb.Selection.Start = new Place(0, 0);
+                tb.Selection.SetStartAndEnd(new Place(0, 0));
                 return Find(pattern);
             }
             return false;
@@ -155,7 +155,7 @@ namespace FastColoredTextBoxNS
                 if (ranges.Count > 0)
                 {
                     tb.TextSource.Manager.ExecuteCommand(new ReplaceTextCommand(tb.TextSource, ranges, tbReplace.Text));
-                    tb.Selection.Start = new Place(0, 0);
+                    tb.Selection.SetStartAndEnd(new Place(0, 0));
                 }
                 //
                 tb.Invalidate();

--- a/Tester/PowerfulCSharpEditor.cs
+++ b/Tester/PowerfulCSharpEditor.cs
@@ -824,7 +824,7 @@ namespace Tester
             //get text of selected lines
             string text = Environment.NewLine + CurrentTB.Selection.Text;
             //move caret to end of selected lines
-            CurrentTB.Selection.Start = CurrentTB.Selection.End;
+            CurrentTB.Selection.SetStartAndEnd(CurrentTB.Selection.End);
             //insert text
             CurrentTB.InsertText(text);
         }
@@ -840,7 +840,7 @@ namespace Tester
             //comment lines
             CurrentTB.InsertLinePrefix("//");
             //move caret to end of selected lines
-            CurrentTB.Selection.Start = CurrentTB.Selection.End;
+            CurrentTB.Selection.SetStartAndEnd(CurrentTB.Selection.End);
             //insert text
             CurrentTB.InsertText(text);
             //end of autoUndo block

--- a/Tester/PowerfulSample.cs
+++ b/Tester/PowerfulSample.cs
@@ -256,7 +256,7 @@ namespace Tester
                 if (counter == 1)
                 {
                     //found
-                    tb.Selection.Start = range.Start;
+                    tb.Selection.SetStartAndEnd(range.Start);
                     tb.DoSelectionVisible();
                     break;
                 }
@@ -279,7 +279,7 @@ namespace Tester
                 if (counter == -1)
                 {
                     //found
-                    tb.Selection.Start = range.Start;
+                    tb.Selection.SetStartAndEnd(range.Start);
                     tb.Selection.GoRightThroughFolded();
                     tb.DoSelectionVisible();
                     break;

--- a/TesterVB/BookmarksSample.resx
+++ b/TesterVB/BookmarksSample.resx
@@ -153,7 +153,7 @@ Public Class BookmarksSample
         Dim id As Integer = bookmarks(iBookmark)
         For i As Integer = 0 To fctb.LinesCount - 1
             If fctb(i).UniqueId = id Then
-                fctb.Selection.Start = New Place(0, i)
+                fctb.Selection.SetStartAndEnd(New Place(0, i))
                 fctb.DoSelectionVisible()
                 fctb.Invalidate()
                 Exit For


### PR DESCRIPTION
**Short:**
I have observed that the Range Start setter also changes the end field. That leads to

* bugs like that the TextChangedEventArgs.ChangedRange is always reduced to the last range instead of the indended merging of ranges (see FastColoredTextBox:OnTextChanged(TextChangedEventArgs args), 6019-6038)
* unnecessary assignments because often the code first changes the Start of a Range and then exlicitly sets End property as well

**Long**
* The setter of ```Range.Start``` modifies ```Range.End```. Start and End are equal. That may lead to unexpected behavior.
* In the function mentioned above ```updatingRange.Start``` is overwritten and such the bottom end of the accumulated range ```updatingRange.End``` gets lost. This also leads to ```updatingRange.GetIntersectionWith(Range)``` being a noop but much more important: The ChangedRange will always only be line that was changed at last.

I have fixed that issue in this PR. Because it is hard to see where this behavior (Start == End) is required I have added a function ```SetStartAndEnd``` that is explicitly doing what it says: Setting Start and End at the same time. Then I went through all the code and have inserted that function whereever Range.Start was assigned and not Range.End was assigned in the next line:
`TB.Selection.Start = new Place(0, LineIndex)`

Also have left lines untouched that are assigning End to Start:
`Start = End;` 

In the second step I have changed the Range.Start setter to not any longer modify Range.End.

I have also created a sample application that demonstrates that behavior, but it is not part of this PR. You can find it here:
https://github.com/codingdave/FastColoredTextBox/tree/fix/TextChangedEventArgs-ChangedRange-Sample

These are the screenshots of the sample. Green is unchanged text, Red is the ```ChangedRange``` and black is the new text that is added and not part of the ```ChangedRange```, so you can say that is the error that this PR fixes.

*Before the fix*
<img width="268" alt="2020-10-09_15-28-41" src="https://user-images.githubusercontent.com/3075641/95590823-d441c280-0a46-11eb-82c4-3a8b239bfe6f.png">

*After the fix*
<img width="268" alt="2020-10-09_15-28-46" src="https://user-images.githubusercontent.com/3075641/95590835-d6a41c80-0a46-11eb-9b90-47adb9659f36.png">

One further note: I have left the VB code untouched, as this is not my comfortable language.






