### PR TITLE
XML - end tag fix

### DIFF
--- a/FastColoredTextBox/SyntaxHighlighter.cs
+++ b/FastColoredTextBox/SyntaxHighlighter.cs
@@ -901,7 +901,7 @@ namespace FastColoredTextBoxNS
             XMLCommentRegex1 = new Regex(@"(<!--.*?-->)|(<!--.*)", RegexOptions.Singleline | RegexCompiledOption);
             XMLCommentRegex2 = new Regex(@"(<!--.*?-->)|(.*-->)",
                                           RegexOptions.Singleline | RegexOptions.RightToLeft | RegexCompiledOption);
-            XMLTagRegex = new Regex(@"<\?|<|/>|</|>|\?>", RegexCompiledOption);
+            XMLTagRegex = new Regex(@"<\?|</|>|<|/>|\?>", RegexCompiledOption);
             XMLTagNameRegex = new Regex(@"<[?](?<range1>[x][m][l]{1})|<(?<range>[!\w:]+)", RegexCompiledOption);
             XMLEndTagRegex = new Regex(@"</(?<range>[\w:]+)>", RegexCompiledOption);
             XMLTagContentRegex = new Regex(@"<[^>]+>", RegexCompiledOption);


### PR DESCRIPTION
The original XMLTagRegex does not match the slash in the closing tag, causing a different color to be shown instead of the color defined in TagBracket style

This can be reproduced using a RegEx tester:

Example XML:
`<foo>foobar</foo>`

Original RegEx: <\?|<|/>|</|>|\?>
![FastColorTextBox-RegEx example](https://user-images.githubusercontent.com/14042884/136810602-59c6fab3-22be-4fdd-80c5-9cf8293dc216.png)

Updated RegEx: <\?|</|>|<|/>|\?>
![FastColorTextBox-RegEx example Improved](https://user-images.githubusercontent.com/14042884/136810659-1c0977ca-f261-407b-95ef-dc6aa107851a.png)

Note:
I have created the custom dark mode like this:

```
using FastColoredTextBoxNS;
using System.Drawing;
using System.Xml.Linq;

namespace MyCommon.Controls
{
    /// <summary>
    /// Extension to FastColoredTextBox for XML files, which includes dark mode
    /// </summary>
    public sealed class XmlHighlighter : FastColoredTextBox
    {
        private readonly TextStyle _commentStyle = new TextStyle(Brushes.LimeGreen, null, FontStyle.Regular);
        private readonly TextStyle _foldedBlockStyle = new TextStyle(Brushes.CornflowerBlue, Brushes.MidnightBlue, FontStyle.Regular);
        private readonly TextStyle _xmlTagBracketStyle = new TextStyle(Brushes.DimGray, null, FontStyle.Regular);
        private readonly TextStyle _xmlTagNameStyle = new TextStyle(Brushes.CornflowerBlue, null, FontStyle.Regular);
        private readonly TextStyle _xmlAttributeStyle = new TextStyle(Brushes.LightSkyBlue, null, FontStyle.Regular);
        private readonly TextStyle _xmlAttributeValueStyle = new TextStyle(Brushes.DarkSalmon, null, FontStyle.Regular);

        /// <summary>
        /// Sets the language to XML and activates dark mode by default
        /// </summary>
        public XmlHighlighter()
        {
            Language = Language.XML;
            SetDarkMode();
        }

        /// <summary>
        /// Sets the language to XML and optionally activates dark mode
        /// </summary>
        public XmlHighlighter(bool enableDarkMode)
        {
            Language = Language.XML;
            if (enableDarkMode) SetDarkMode();
        }

        public string Xml
        {
            set
            {
                var xDocument = XDocument.Parse(value);
                Text = xDocument.ToString();
            }
        }

        private void SetDarkMode()
        {
            // Set control to custom dark mode
            BackColor = Color.Black;
            ForeColor = Color.FloralWhite;
            IndentBackColor = Color.Black;
            Font = new Font("Consolas", 12f, FontStyle.Regular);
            FoldedBlockStyle = _foldedBlockStyle;
            SyntaxHighlighter.XmlAttributeStyle = _xmlAttributeStyle;
            SyntaxHighlighter.XmlAttributeValueStyle = _xmlAttributeValueStyle;
            SyntaxHighlighter.XmlTagBracketStyle = _xmlTagBracketStyle;
            SyntaxHighlighter.XmlTagNameStyle = _xmlTagNameStyle;
            SyntaxHighlighter.CommentStyle = _commentStyle;
            SelectionColor = Color.SkyBlue;
        }
    }
}

```

